### PR TITLE
correct case of main file to match the package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jQuery.serializeObject",
   "version": "2.0.3",
-  "main": "jQuery.serializeObject.js",
+  "main": "jquery.serializeObject.js",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
When using the package in Linux with brunch/bower the main file can not be found in brunch build. For some reason, it works under OSX. This patch changes the main property of bower.json to match the exact case of the main .js filename, correcting the issue.
